### PR TITLE
Fix Vuetify integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "start-server-and-test": "^1.14.0",
         "typescript": "~4.7.4",
         "vite": "^3.1.8",
+        "vite-plugin-vuetify": "^1.0.0-alpha.12",
         "vue-cli-plugin-vuetify": "~2.5.8",
         "vue-tsc": "^1.0.8",
         "webpack-plugin-vuetify": "^2.0.0-alpha.0"
@@ -4973,6 +4974,24 @@
         }
       }
     },
+    "node_modules/vite-plugin-vuetify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-1.0.0.tgz",
+      "integrity": "sha512-30+W6H//wjOegKCha4wQ3IS+JyXDE6IayL5cK5S4IrM7WIceV/WitnxljbPZHER+Jyl3BGIuYV6nofjMOfRO1g==",
+      "dev": true,
+      "dependencies": {
+        "@vuetify/loader-shared": "^1.7.0",
+        "debug": "^4.3.3",
+        "upath": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "vite": "^2.7.0 || ^3.0.0",
+        "vuetify": "^3.0.0-beta.4"
+      }
+    },
     "node_modules/vue": {
       "version": "3.2.41",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.41.tgz",
@@ -8791,6 +8810,17 @@
         "postcss": "^8.4.18",
         "resolve": "^1.22.1",
         "rollup": "^2.79.1"
+      }
+    },
+    "vite-plugin-vuetify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-1.0.0.tgz",
+      "integrity": "sha512-30+W6H//wjOegKCha4wQ3IS+JyXDE6IayL5cK5S4IrM7WIceV/WitnxljbPZHER+Jyl3BGIuYV6nofjMOfRO1g==",
+      "dev": true,
+      "requires": {
+        "@vuetify/loader-shared": "^1.7.0",
+        "debug": "^4.3.3",
+        "upath": "^2.0.1"
       }
     },
     "vue": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "booksstore",
   "version": "0.0.0",
   "scripts": {
-    "build": "run-p type-check build-only",
+    "serve": "vite preview",
+    "build": "vite build",
     "test:unit": "cypress run --component",
     "test:e2e": "start-server-and-test preview :4173 'cypress run --e2e'",
     "build-only": "vite build",
@@ -31,6 +32,7 @@
     "start-server-and-test": "^1.14.0",
     "typescript": "~4.7.4",
     "vite": "^3.1.8",
+    "vite-plugin-vuetify": "^1.0.0-alpha.12",
     "vue-cli-plugin-vuetify": "~2.5.8",
     "vue-tsc": "^1.0.8",
     "webpack-plugin-vuetify": "^2.0.0-alpha.0"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,6 @@ import vueJsx from '@vitejs/plugin-vue-jsx'
 // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
 import vuetify from 'vite-plugin-vuetify'
 
-// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
-import vuetify from 'vite-plugin-vuetify'
-
-// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
-import vuetify from 'vite-plugin-vuetify'
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,22 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 
+// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
+import vuetify from 'vite-plugin-vuetify'
+
+// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
+import vuetify from 'vite-plugin-vuetify'
+
+// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
+import vuetify from 'vite-plugin-vuetify'
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueJsx()],
+  plugins: [
+		vue(),
+		vueJsx(),
+		vuetify({ autoImport: true }),
+	],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  pluginOptions: {
-    vuetify: {
-			// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vuetify-loader
-		}
-  }
-}


### PR DESCRIPTION
- Ajout de Vuetify dans la configuration Vite, pour charger les composants
- Les scripts du package.json utilise vite désormais (c'est recommandé)
- Supression de vue.config.js c'est Vite qui est installé sur ce projet